### PR TITLE
altar, corpses/skulls, readded dropping?

### DIFF
--- a/item.js
+++ b/item.js
@@ -484,6 +484,12 @@ class item
 				this.blade = 6;
 				this.attackDescriptor = "slash";
 				this.rareLoot = true;
+				
+				//give it some enchantments
+				this.enchanted = true;
+				this.cursed = false;
+				this.effect = "concussion";
+				this.magicalCharge = 10;
 				break;
 
 			case "wand_fireball":

--- a/item.js
+++ b/item.js
@@ -57,6 +57,7 @@ class item
 				this.name = "Spider Carcass";
 				this.character = "c";
 				this.description = "The carcass of a dead spider.";
+				this.canDrop = true;
 				break;
 
 			case "skeleton_bone":
@@ -121,6 +122,19 @@ class item
 				this.character = "k";
 				this.description = "A battered old key.";
 				break;
+				
+			case "corpseHero": 
+				this.class = "junk";
+				this.name = "Hero Skull";
+				this.character = "k";
+				this.description = "The skull of a heroic champion that perished in the dungeon.";
+				break;
+			case "corpseCleric": 
+				this.class = "junk";
+				this.name = "Priest Skull";
+				this.character = "k";
+				this.description = "The skull of a lowly healer that perished in the dungeon.";
+				break;				
 
 			case "fists":
 				this.class = "weapon";
@@ -765,6 +779,9 @@ class item
 				this.staminaEffect = 0;
 				this.specialEffect = "antipoison+";
 				break;
+				
+			
+
 
 			default:
 				throw "Unknown item type " + type;
@@ -862,6 +879,11 @@ class item
 
 		if(location !== null)
 			this.moveTo(location);
+	}
+	
+	getClass() 
+	{
+		return this.class;
 	}
 
 	getName()

--- a/item.js
+++ b/item.js
@@ -473,6 +473,18 @@ class item
 				this.baseWeapon = true;
 				this.rareLoot = true;
 				break;
+				
+			case "lightbringer":
+				this.class = "weapon";
+				this.name = "Lightbringer";
+				this.character = "l";
+				this.description = "The slim and slender Lightbringer is fortold to bring radiance even to the darkest places.";
+				this.weight = 0;
+				this.blunt = 0;
+				this.blade = 6;
+				this.attackDescriptor = "slash";
+				this.rareLoot = true;
+				break;
 
 			case "wand_fireball":
 				this.class = "wand";

--- a/main.js
+++ b/main.js
@@ -153,7 +153,6 @@ function updateDisplay()
 
 					if(tile.hazard.useHazardFlash)
 						displayTile.classList.add("hazardBackground");
-					
 					style = style + "color: " + tile.hazard.color + ";";
 
 					if(tile.unit !== null)
@@ -253,7 +252,7 @@ function updateDisplay()
 			else if(inventory[i].class == "wand")
 				html = html + ' <button onclick="zap(' + i + ')" class="' + className +'" ' + allButtonsProperties + '>Zap</button>';
 
-			if(gameStage == 2 && inventory[i] != player.weapon && inventory[i].canDrop)
+			if((inventory[i] != player.weapon) && (inventory[i].canDrop == true))
 				html = html + ' <button onclick="drop(' + i + ')" class="' + className +'" ' + allButtonsProperties + '>Drop</button>';
 
 
@@ -656,7 +655,7 @@ function loadMap(mapText, mapInfo, customMap)
 				break;
 			case ",":
 				world[x][y].base = new tileBase("floor", {x, y});
-				world[x][y].hazard = new Hazard("speartrap_off", {x,y});
+				world[x][y].hazard = new hazard("speartrap_off", {x,y});
 				break;
 			case "+":
 				world[x][y].base = new tileBase("door", {x, y});
@@ -726,7 +725,13 @@ function loadMap(mapText, mapInfo, customMap)
 			case "F":
 				world[x][y].base = new tileBase("bossDoor", {x, y});
 				break;
-
+			case "A":
+				world[x][y].base = new tileBase("altar", {x, y});
+				break;
+			case "J":
+				world[x][y].base = new tileBase("floor", {x, y});
+				world[x][y].items[0] = new item(getJunkDrop(0), {x, y});
+				break;
 			default:
 				world[x][y].base = new tileBase("wall", {x, y});
 				errors++;
@@ -1544,27 +1549,71 @@ function drop(slot)
 	if(!yourTurn)
 		return;
 
-	let item = inventory[slot];
+	let droppingItem = inventory[slot];
 
-	if(item === undefined)
+	if(droppingItem === undefined)
 		return;
 
-	if(!item.canDrop)
+	if(!droppingItem.canDrop)
 	{
 		addLog("You can't drop that.");
 		return;
 	}
 
-	if(item != player.weapon)
+	if(droppingItem != player.weapon)
 	{
-		addLog("You drop the " + item.getName() + "...");
+		let tile = getWorld(northOf(player.location));
+		
+		if(tile.base.getName() == "Marble Altar") {
 
-		inventory.splice(slot, 1);
-		item.moveTo(player.location);
-		groundItems.push(item);
-		item.dropped = true;
-
+			if(droppingItem.getName() == "Spider Carcass") {
+				addLog("You put the " + droppingItem.getName() + " on the altar.");
+				addLog("A magical light fills the room and consumes the " + droppingItem.getName());
+				addLog("A smouldering potion is left on the altar...");
+				droppingItem.remove();
+				let newItem = new item("antipoison_potion");
+				inventory.push(newItem);
+			} else if(droppingItem.getName() == "Hero Skull") {
+				addLog("You put the " + droppingItem.getName() + " on the altar.");
+				addLog("A magical light fills the room and consumes the " + droppingItem.getName());
+				addLog("A smouldering potion is left on the altar...");
+				droppingItem.remove();
+				
+				//try to override the weapon since they autoenchant
+				weapon = new item("longsword");
+				weapon.enchanted = true;
+				weapon.cursed = false;
+				weapon.effect = "concussion";
+				weapon.magicalCharge = 10;
+				weapon.realName = "Lightbringer";
+				weapon.realDescription = "The slim and slender Lightbringer is fortold to bring radiance even to the darkest places. The enchantment will slowly build up energy during combat, and then release all of it in a concussive blast once fully charged."
+				weapon.identify();
+				
+				inventory.push(weapon);
+				
+			} else if(droppingItem.getName() == "Priest Skull") {
+				addLog("You put the " + droppingItem.getName() + " on the altar.");
+				addLog("A magical light fills the room and consumes the " + droppingItem.getName());
+				addLog("A smouldering potion is left on the altar...");
+				droppingItem.remove();
+				inventory.push(new item("health_potion"));
+			} else {
+				addLog("You drop the " + droppingItem.getName() + "...");
+				inventory.splice(slot, 1);
+				droppingItem.moveTo(player.location);
+				groundItems.push(droppingItem);
+				droppingItem.dropped = true;
+			}
+		} else {
+			addLog("You drop the " + droppingItem.getName() + "...");
+			inventory.splice(slot, 1);
+			droppingItem.moveTo(player.location);
+			groundItems.push(droppingItem);
+			droppingItem.dropped = true;
+		}
+		
 		inventoryUpdate = true;
+		
 		if(quickActionUsed)
 			bulletTime();
 		else
@@ -1572,14 +1621,20 @@ function drop(slot)
 			quickActionUsed = true;
 			updateDisplay();
 		}
+		
 	}
 }
 
 // Drop lists
+var junkDrops = Array("corpseHero","corpseCleric");
 var commonDrops = Array("health_potion", "stamina_potion", "energy_potion", "refresh_potion", "posion_potion", "fatigue_potion", "disintegrate_potion", "placebo_potion", "identify_potion", "defence_potion", "frail_potion", "agility_potion", "slug_potion", "exp_potion", "forget_potion", "antipoison_potion", "disc", "coin", "key", "bat", "knuckles", "dagger");
 var uncommonDrops = Array("longsword", "rapier", "mace", "sledgehammer", "greatsword", "flail", "wand_giestflame", "wand_snowball");
 var rareDrops = Array("wand_fireball", "wand_frostbolt", "wand_missle", "wand_concussion", "super_health_potion", "super_stamina_potion", "super_antipoison_potion", "zweihander", "odachi", "nunchucks", "scimitar");
 var ultraRareDrops = Array("wand_firestorm", "levelup_potion", "muramasa", "kusanagi", "joyeuse", "nyantana");
+
+function getJunkDrop(levelModifier) {
+	return junkDrops[getRandom(0, junkDrops.length - 1)];
+}
 
 function getCommonDrop(levelModifier)
 {

--- a/main.js
+++ b/main.js
@@ -1580,13 +1580,11 @@ function drop(slot)
 				droppingItem.remove();
 				
 				//try to override the weapon since they autoenchant
-				weapon = new item("longsword");
+				weapon = new item("lightbringer");
 				weapon.enchanted = true;
 				weapon.cursed = false;
 				weapon.effect = "concussion";
 				weapon.magicalCharge = 10;
-				weapon.realName = "Lightbringer";
-				weapon.realDescription = "The slim and slender Lightbringer is fortold to bring radiance even to the darkest places. The enchantment will slowly build up energy during combat, and then release all of it in a concussive blast once fully charged."
 				weapon.identify();
 				
 				inventory.push(weapon);

--- a/tilebase.js
+++ b/tilebase.js
@@ -100,6 +100,14 @@ class tileBase
 				permitsVision = true;
 				permitsTravel = true;
 				break;
+				
+			case "altar":
+				description = "A marble altar that glows with divine energy.";
+				name = "Marble Altar";
+				character = "┯";
+				permitsVision = true;
+				permitsTravel = false;
+				break;	
 
 			default:
 				description = "A nondescript tile. Something probably went wrong with the world generator.";
@@ -288,6 +296,10 @@ class tileBase
 						gameStage = 4;
 					}
 					break;
+				case "altar": 
+					message = "You smash your hip on the edge of the marble altar. Ouch!";
+					success = false;
+					break;
 
 				default:
 					message = "You step into the glitch, and suddenly reappear where you were before." + this.typeName;
@@ -403,6 +415,11 @@ class tileBase
 
 			case "sealedDoor":
 				message = "You futily swing your " + unit.weapon.getName() + " at the magically sealed door, but it might as well be made of solid adamantium for how much it gives.";
+				success = false;
+				break;
+				
+			case "altar":
+				message = "You smash your " + unit.weapon.getName() + " at the magically altar, but its stone stays pristine.";
 				success = false;
 				break;
 

--- a/unit.js
+++ b/unit.js
@@ -41,7 +41,7 @@ class unit
 
 				maxHealth = 25;
 				maxStamina = 20;
-				level = 10;
+				level = 10; 
 				break;
 
 			case "rat":
@@ -368,8 +368,8 @@ class unit
 
 			for(let i = tile.items.length; i > 0; i--)
 			{
-				if(tile.items[tile.items.length - 1].dropped)
-					continue;
+				//if(tile.items[tile.items.length - 1].dropped)
+				//	continue;
 
 				let pickup = tile.items.pop();
 				inventory.push(pickup);

--- a/unit.js
+++ b/unit.js
@@ -368,8 +368,8 @@ class unit
 
 			for(let i = tile.items.length; i > 0; i--)
 			{
-				//if(tile.items[tile.items.length - 1].dropped)
-				//	continue;
+				if(tile.items[tile.items.length - 1].dropped)
+					continue;
 
 				let pickup = tile.items.pop();
 				inventory.push(pickup);


### PR DESCRIPTION
Altar lets you sacrifice a corpse (right now Spider Carcass, Hero Skull, and Priest Skull) to get items. Added skulls, though none spawn. Added junkDrop list which only has the two skulls in it. Once again none spawn. Readded the ability to drop because it was turned off for some reason? I see nothing that lets it go into gameState 2.